### PR TITLE
Ignore catalog-migrate directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work.sum
 
 # env file
 .env
+
+catalog-migrate-*


### PR DESCRIPTION
The opm tooling generates these directories, so let's not check them
into the repository.
