### PR TITLE
Add latest tag to each FBC image

### DIFF
--- a/.tekton/file-integrity-operator-fbc-4-12-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-12-push.yaml
@@ -306,6 +306,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-fbc-4-13-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-13-push.yaml
@@ -306,6 +306,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-fbc-4-14-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-14-push.yaml
@@ -306,6 +306,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-fbc-4-15-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-15-push.yaml
@@ -306,6 +306,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-fbc-4-16-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-16-push.yaml
@@ -306,6 +306,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-fbc-4-17-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-17-push.yaml
@@ -306,6 +306,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-fbc-4-18-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-18-push.yaml
@@ -307,6 +307,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/file-integrity-operator-fbc-4-19-push.yaml
+++ b/.tekton/file-integrity-operator-fbc-4-19-push.yaml
@@ -307,6 +307,9 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: ADDITIONAL_TAGS
+        value:
+          - latest
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Adding the `latest` tag to each FBC image makes it easier to fetch the
latest image for each FBC, which we can use to find the correct digest
without having to dig for it manually in Konflux or Quay.

The additional tag is only `latest`, instead of doing something like
`fio-fbc-4-12-latest` since the image repository is already specific to
each OpenShift version and the application, meaning we can keep the
latest tag simple.
