### PR TITLE
Add all supported OCP versions to the update.sh script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # --- CONFIGURATION ---
-OCP_VERSIONS=(4.16)
+OCP_VERSIONS=(4.12 4.13 4.14 4.15 4.16 4.17 4.18 4.19)
 
 # Old (tag-based) image:
 NEW_BUNDLE="quay.io/redhat-user-workloads/ocp-isc-tenant/file-integrity-operator-bundle-release:release-1.3"


### PR DESCRIPTION
Let's generate FBCs for all currently supported versions of OpenShift.
This saves us a step since we don't need to pass it all in when we call
the tool.
