### PR TITLE
Update 4.19 container file

### DIFF
--- a/catalog/v4.19/Containerfile
+++ b/catalog/v4.19/Containerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
Let's make sure we're using images from registry.redhat.io instead of
brew, which is what the EC testing checks for.
