### PR TITLE
Fix ImageDigestMirrorSet api

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,4 +1,4 @@
-apiVersion: operator.openshift.io/v1alpha1
+apiVersion: config.openshift.io/v1alpha1
 kind: ImageDigestMirrorSet
 metadata:
   name: file-integrity-operator-mirror-set


### PR DESCRIPTION
It looks like the `ImageDigestMirrorSet` `apiversion` is wrong.

See error in https://github.com/openshift/file-integrity-operator-fbc/pull/66:

`
file-integrity-operator-mirror-set 	no kind "ImageDigestMirrorSet" is registered for version "operator.openshift.io/v1alpha1" in scheme "k8s.io/client-go/kubernetes/scheme/register.go:83"
`

https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/config_apis/imagedigestmirrorset-config-openshift-io-v1
