### PR TITLE
Fix ImageDigestMirrorSet apiversion again

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.openshift.io/v1alpha1
+apiVersion: config.openshift.io/v1
 kind: ImageDigestMirrorSet
 metadata:
   name: file-integrity-operator-mirror-set


### PR DESCRIPTION
Looks like the api is not alpha anymore

Follow up from #67 